### PR TITLE
Moved db code to persist package and put it behind an interface

### DIFF
--- a/src/main/java/org/lumenframework/demo/notes/controllers/NoteEditController.java
+++ b/src/main/java/org/lumenframework/demo/notes/controllers/NoteEditController.java
@@ -10,16 +10,13 @@ import lumen.system.Annotations.Controller;
 import lumen.system.Annotations.Key;
 import lumen.system.Annotations.LumenEnabled;
 
-import org.lumenframework.demo.notes.DataStore;
-import org.lumenframework.demo.notes.Note;
+import org.lumenframework.demo.notes.persist.PersistableNoteH2Impl;
 
 import com.google.common.collect.Maps;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.DaoManager;
 
 @Controller
 public class NoteEditController {
-	
+
 	@LumenEnabled
     public static Component saveNote(@Key("id")Long id,
     								 @Key("title")String title,
@@ -27,29 +24,13 @@ public class NoteEditController {
     								 @Key("sort")String sort,
     								 @Key("latitude")BigDecimal latitude,
     								 @Key("longitude")BigDecimal longitude) throws Exception {
-		Dao<Note, Long> noteDao = DaoManager.createDao(DataStore.getInstance().getConnectionSource(), Note.class);
 
-		Note note;
-		if(id != null){
-			note = noteDao.queryForId(id);
-		}else{
-			note = new Note();
-		}
-		note.setTitle(title);
-		note.setBody(body);
-		if(latitude != null && longitude != null){
-			note.setLatitude(latitude.doubleValue());
-			note.setLongitude(longitude.doubleValue());
-		}
+		PersistableNoteH2Impl persistImpl = new PersistableNoteH2Impl();
+		persistImpl.saveNote(id, title, body, latitude, longitude);
 
-		if(id != null){
-			noteDao.update(note);
-		}else{
-			noteDao.create(note);
-		}
 		Map<String, Object> listAttributes = Maps.newHashMap();
 		listAttributes.put("sort", sort);
-		
+
 		return Lumen.getInstanceService().getInstance("lumennote:noteList", ComponentDef.class, listAttributes);
 	}
 }

--- a/src/main/java/org/lumenframework/demo/notes/controllers/NoteViewController.java
+++ b/src/main/java/org/lumenframework/demo/notes/controllers/NoteViewController.java
@@ -9,20 +9,17 @@ import lumen.system.Annotations.Controller;
 import lumen.system.Annotations.Key;
 import lumen.system.Annotations.LumenEnabled;
 
-import org.lumenframework.demo.notes.DataStore;
-import org.lumenframework.demo.notes.Note;
+import org.lumenframework.demo.notes.persist.PersistableNoteH2Impl;
 
 import com.google.common.collect.Maps;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.DaoManager;
 
 @Controller
 public class NoteViewController {
 
     @LumenEnabled
     public static Component deleteNote(@Key("id")Long id, @Key("sort")String sort) throws Exception {
-        Dao<Note, Long> noteDao = DaoManager.createDao(DataStore.getInstance().getConnectionSource(), Note.class);
-        noteDao.deleteById(id);
+		PersistableNoteH2Impl persistImpl = new PersistableNoteH2Impl();
+		persistImpl.deleteById(id);
 
         Map<String, Object> listAttributes = Maps.newHashMap();
         listAttributes.put("sort", sort);

--- a/src/main/java/org/lumenframework/demo/notes/controllers/TestNoteListController.java
+++ b/src/main/java/org/lumenframework/demo/notes/controllers/TestNoteListController.java
@@ -7,8 +7,8 @@ import lumen.system.Annotations.Key;
 import lumen.system.Annotations.LumenEnabled;
 import lumen.util.TextUtil;
 
-import org.lumenframework.demo.notes.DataStore;
 import org.lumenframework.demo.notes.Note;
+import org.lumenframework.demo.notes.persist.DataStore;
 
 import com.google.common.collect.Lists;
 import com.j256.ormlite.dao.*;

--- a/src/main/java/org/lumenframework/demo/notes/models/NoteListModel.java
+++ b/src/main/java/org/lumenframework/demo/notes/models/NoteListModel.java
@@ -6,15 +6,9 @@ import lumen.Lumen;
 import lumen.instance.BaseComponent;
 import lumen.system.Annotations.LumenEnabled;
 import lumen.system.Annotations.Model;
-import lumen.util.TextUtil;
-
-import org.lumenframework.demo.notes.DataStore;
 import org.lumenframework.demo.notes.Note;
+import org.lumenframework.demo.notes.persist.PersistableNoteH2Impl;
 
-import com.google.common.collect.Lists;
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.dao.GenericRawResults;
-import com.j256.ormlite.stmt.QueryBuilder;
 
 enum SortCol {
 	title, createdOn
@@ -27,44 +21,13 @@ enum SortDir {
 @Model
 public class NoteListModel {
 
-	private static DataStore dataStore = DataStore.getInstance();
 	private List<Note> notes;
 
 	public NoteListModel() throws Exception {
-		Dao<Note, Long> noteDao = dataStore.getNoteDao();
-
 		BaseComponent<?, ?> cmp = Lumen.getContextService().getCurrentContext().getCurrentComponent();
 
-		List<String> sortSplit = TextUtil.splitSimple(".", (String) cmp.getAttributes().getValue("sort"));
-
-		SortCol sortCol = SortCol.createdOn;
-		SortDir sortDir = SortDir.desc;
-
-		if (sortSplit != null) {
-			sortCol = SortCol.valueOf(sortSplit.get(0));
-			sortDir = SortDir.valueOf(sortSplit.get(1));
-		}
-
-		String query = (String) cmp.getAttributes().getValue("query");
-		QueryBuilder<Note, Long> qb = noteDao.queryBuilder();
-		if (!TextUtil.isNullEmptyOrWhitespace(query)) {
-			List<Long> ids = Lists.newArrayList();
-			GenericRawResults<String[]> searchResults = noteDao.queryRaw("SELECT KEYS FROM FT_SEARCH_DATA(?,0,0)", query);
-			try {
-				for (String[] row : searchResults) {
-					ids.add(Long.parseLong(TextUtil.replaceAllRegex(row[0], "[()]", "")));
-				}
-			} finally {
-				searchResults.close();
-			}
-
-			qb.setWhere(qb.where().in("id", ids));
-		}
-		
-		qb.orderBy(sortCol.name(), sortDir == SortDir.asc);
-		qb.limit(100L);
-
-		notes = qb.query();
+		PersistableNoteH2Impl persistImpl = new PersistableNoteH2Impl();
+		notes = persistImpl.getNoteList(cmp);
 
 		if (notes.isEmpty()) {
 			notes.add(new Note("Sample Note", "Just a simple note to let you know <h1>Lumen</h1> loves you!"));

--- a/src/main/java/org/lumenframework/demo/notes/models/TestNoteListModel.java
+++ b/src/main/java/org/lumenframework/demo/notes/models/TestNoteListModel.java
@@ -5,8 +5,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import lumen.system.Annotations.LumenEnabled;
 import lumen.system.Annotations.Model;
 
-import org.lumenframework.demo.notes.DataStore;
 import org.lumenframework.demo.notes.Note;
+import org.lumenframework.demo.notes.persist.DataStore;
 
 import com.j256.ormlite.dao.Dao;
 import com.j256.ormlite.dao.DaoManager;

--- a/src/main/java/org/lumenframework/demo/notes/persist/DataStore.java
+++ b/src/main/java/org/lumenframework/demo/notes/persist/DataStore.java
@@ -1,9 +1,10 @@
-package org.lumenframework.demo.notes;
+package org.lumenframework.demo.notes.persist;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 
 import org.h2.fulltext.FullText;
+import org.lumenframework.demo.notes.Note;
 
 import com.j256.ormlite.dao.Dao;
 import com.j256.ormlite.dao.DaoManager;

--- a/src/main/java/org/lumenframework/demo/notes/persist/PersistableNote.java
+++ b/src/main/java/org/lumenframework/demo/notes/persist/PersistableNote.java
@@ -1,0 +1,20 @@
+package org.lumenframework.demo.notes.persist;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.util.List;
+
+import lumen.instance.BaseComponent;
+
+import org.lumenframework.demo.notes.Note;
+
+public interface PersistableNote {
+
+	public List<Note> getNoteList(BaseComponent<?, ?> cmp) throws Exception;
+
+	public void deleteById(Long id) throws Exception;
+
+	public void saveNote(Long id, String title, String body, BigDecimal latitude, BigDecimal longitude) throws SQLException;
+
+
+}

--- a/src/main/java/org/lumenframework/demo/notes/persist/PersistableNoteH2Impl.java
+++ b/src/main/java/org/lumenframework/demo/notes/persist/PersistableNoteH2Impl.java
@@ -1,0 +1,96 @@
+package org.lumenframework.demo.notes.persist;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.util.List;
+
+import lumen.instance.BaseComponent;
+import lumen.util.TextUtil;
+
+import org.lumenframework.demo.notes.Note;
+
+
+import com.google.common.collect.Lists;
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.dao.DaoManager;
+import com.j256.ormlite.dao.GenericRawResults;
+import com.j256.ormlite.stmt.QueryBuilder;
+
+enum SortCol {
+	title, createdOn
+};
+
+enum SortDir {
+	asc, desc
+}
+
+public class PersistableNoteH2Impl implements PersistableNote {
+	public List<Note> getNoteList(BaseComponent<?, ?> cmp) throws Exception {
+		List<Note> notes;
+		DataStore dataStore = DataStore.getInstance();
+
+		Dao<Note, Long> noteDao = dataStore.getNoteDao();
+
+		List<String> sortSplit = TextUtil.splitSimple(".", (String) cmp.getAttributes().getValue("sort"));
+
+		SortCol sortCol = SortCol.createdOn;
+		SortDir sortDir = SortDir.desc;
+
+		if (sortSplit != null) {
+			sortCol = SortCol.valueOf(sortSplit.get(0));
+			sortDir = SortDir.valueOf(sortSplit.get(1));
+		}
+
+		String query = (String) cmp.getAttributes().getValue("query");
+		QueryBuilder<Note, Long> qb = noteDao.queryBuilder();
+		if (!TextUtil.isNullEmptyOrWhitespace(query)) {
+			List<Long> ids = Lists.newArrayList();
+			GenericRawResults<String[]> searchResults = noteDao.queryRaw("SELECT KEYS FROM FT_SEARCH_DATA(?,0,0)", query);
+			try {
+				for (String[] row : searchResults) {
+					ids.add(Long.parseLong(TextUtil.replaceAllRegex(row[0], "[()]", "")));
+				}
+			} finally {
+				searchResults.close();
+			}
+
+			qb.setWhere(qb.where().in("id", ids));
+		}
+
+		qb.orderBy(sortCol.name(), sortDir == SortDir.asc);
+		qb.limit(100L);
+
+		notes = qb.query();
+		return notes;
+	}
+
+	public void deleteById(Long id) throws Exception {
+        Dao<Note, Long> noteDao = DaoManager.createDao(DataStore.getInstance().getConnectionSource(), Note.class);
+        noteDao.deleteById(id);
+	}
+
+	public void saveNote(Long id, String title, String body, BigDecimal latitude, BigDecimal longitude)
+		throws SQLException
+	{
+		Dao<Note, Long> noteDao = DaoManager.createDao(DataStore.getInstance().getConnectionSource(), Note.class);
+
+		Note note;
+		if(id != null){
+			note = noteDao.queryForId(id);
+		}else{
+			note = new Note();
+		}
+		note.setTitle(title);
+		note.setBody(body);
+		if(latitude != null && longitude != null){
+			note.setLatitude(latitude.doubleValue());
+			note.setLongitude(longitude.doubleValue());
+		}
+
+		if(id != null){
+			noteDao.update(note);
+		}else{
+			noteDao.create(note);
+		}
+	}
+}


### PR DESCRIPTION
@dpletter @dutchasman I moved db code to a new persist package and put it behind an interface so that the db access code is more centralized and easier to swap out if we ever wanted to switch the db. I didn't edit any of the tests. See what you think.
